### PR TITLE
[#2][#6] Multi-DB support: one database per service + CD manifest strategy

### DIFF
--- a/.env
+++ b/.env
@@ -2,49 +2,72 @@
 #
 # This file is sourced by scripts/sqlx_premigration.sh (if present).
 # Any required variables not set here will cause the script to fail.
-#
-# SQLx notes:
-# - sqlx uses DATABASE_URL by default for `sqlx database create` and `sqlx migrate run`
-# - the application should use APP_DATABASE_URL at runtime
-# - TABLE_CREATOR_DATABASE_URL is optional (only if you provision tables at runtime)
 
 # -----------------------------------------------------------------------------
-# script config
+# Script config
 # -----------------------------------------------------------------------------
-APP_ENV=test # Only for pg_tests container; allowed: prod, dev, stage, test (case-insensitive)
-# DEBUG= # Enable verbose logging in scripts
-# ENV_PATH= # Override path to .env file
-# # PG_LOG=1   # If set, stream postgres logs to stdout (pg_tests container only)
-# PG_TEST_LOG=
+APP_ENV=test
+# DEBUG=1       # Enable verbose logging
+# PG_LOG=1      # Stream postgres logs to stdout (test container only)
+# PG_TEST_LOG=1 # Stream pgTAP output
 
 # -----------------------------------------------------------------------------
 # Database identity / networking
 # -----------------------------------------------------------------------------
 DB_HOST=127.0.0.1
-DB_PORT=2345 # FIXME: this is counterintuitive, the pg_db port should default to 5432
-APP_DB_NAME=mae_test
-SEARCH_PATH=app # INTERNAL, do not change, removed from ENV capture script.
+DB_PORT=5432
+APP_DB_NAME=mae_test       # Used in single-DB mode (backward compat)
+SEARCH_PATH=app            # INTERNAL – do not change
 SQLX_OFFLINE=true
 
 # -----------------------------------------------------------------------------
+# Multi-DB mode: one database per service
+# Set PG_MAE_DATABASES to activate multi-DB mode.
+# Comma-separated list of database names; service name is derived by stripping
+# a trailing _db suffix (e.g. api_db → service api).
+# -----------------------------------------------------------------------------
+# PG_MAE_DATABASES=api_db,accounting_db,widget_db,queue_db
+
+# -----------------------------------------------------------------------------
 # Postgres bootstrap superuser
-# (used only by sqlx_premigration.sh / init scripts)
 # -----------------------------------------------------------------------------
 SUPERUSER=postgres
 SUPERUSER_PWD=password
 
 # -----------------------------------------------------------------------------
-# LOGIN roles created by premigration script
+# Single-DB mode: LOGIN roles (used when PG_MAE_DATABASES is NOT set)
 # -----------------------------------------------------------------------------
-
-# Used by SQLx migrations
 MIGRATOR_USER=db_migrator
 MIGRATOR_PWD=migrator_secret
 
-# Used by the application at runtime (inherits app_user)
 APP_USER=app
 APP_USER_PWD=secret
 
-# Optional: only if you create tables at runtime (inherits table_creator)
 TABLE_PROVISIONER_USER=table_provisioner
 TABLE_PROVISIONER_PWD=provisioner_secret
+
+# -----------------------------------------------------------------------------
+# Multi-DB mode: per-service credentials
+# Pattern: {SERVICE_UPPER}_MIGRATOR_PWD / _APP_USER_PWD / _PROVISIONER_PWD
+# Login role names are derived: {service}_migrator, {service}_app, {service}_provisioner
+# -----------------------------------------------------------------------------
+
+# api_db → service: api → roles: api_migrator, api_app, api_provisioner
+API_MIGRATOR_PWD=api_migrator_secret
+API_APP_USER_PWD=api_app_secret
+API_PROVISIONER_PWD=api_provisioner_secret
+
+# accounting_db → service: accounting → roles: accounting_migrator, accounting_app, accounting_provisioner
+ACCOUNTING_MIGRATOR_PWD=accounting_migrator_secret
+ACCOUNTING_APP_USER_PWD=accounting_app_secret
+ACCOUNTING_PROVISIONER_PWD=accounting_provisioner_secret
+
+# widget_db → service: widget → roles: widget_migrator, widget_app, widget_provisioner
+WIDGET_MIGRATOR_PWD=widget_migrator_secret
+WIDGET_APP_USER_PWD=widget_app_secret
+WIDGET_PROVISIONER_PWD=widget_provisioner_secret
+
+# queue_db → service: queue → roles: queue_migrator, queue_app, queue_provisioner
+QUEUE_MIGRATOR_PWD=queue_migrator_secret
+QUEUE_APP_USER_PWD=queue_app_secret
+QUEUE_PROVISIONER_PWD=queue_provisioner_secret

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,6 @@ RUN set -eux; \
     libssl-dev \
     perl \
     postgresql-common \
-    docker.io \
   ; \
   rm -rf /var/lib/apt/lists/*
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,167 @@
-SOURCES:
+# postgres-mae
 
-https://pgtap.org/documentation.html#has_column
-https://pgpedia.info/search.html
+A hardened, opinionated Postgres base image for Mae-Technologies services.
+
+`postgres-mae` extends the official `postgres` image. At startup it:
+1. Starts Postgres
+2. Runs admin premigrations (creates databases, schemas, roles, ACLs)
+3. Runs pgTAP tests against every database and every principal
+4. Stays running as a normal Postgres server (in non-test envs)
+
+Image is published to **GHCR**: `ghcr.io/mae-technologies/postgres-mae`
+
+---
+
+## One Database Per Service
+
+Each Mae-Technologies backend service (`api`, `accounting`, `widget`, `queue`) gets
+its **own isolated database**. No database is shared between services. This
+provides:
+
+- Hard data isolation — a bug in one service cannot corrupt another's data
+- Independent schema evolution — each service migrates its own DB
+- Per-service access control — credentials are scoped to one database
+
+### Database names (canonical)
+
+| Service    | Database        |
+|------------|-----------------|
+| api        | `api_db`        |
+| accounting | `accounting_db` |
+| widget     | `widget_db`     |
+| queue      | `queue_db`      |
+
+---
+
+## Configuration
+
+### Multi-DB mode (recommended)
+
+Set `PG_MAE_DATABASES` to a comma-separated list of database names:
+
+```
+PG_MAE_DATABASES=api_db,accounting_db,widget_db,queue_db
+```
+
+For each database, the **service name** is derived by stripping a trailing `_db`
+suffix (`api_db` → `api`). Per-service login roles are created automatically:
+
+| Role pattern          | Inherits                      | Purpose                      |
+|-----------------------|-------------------------------|------------------------------|
+| `{service}_migrator`  | `app_migrator` + `app_user`   | Run SQLx migrations          |
+| `{service}_app`       | `app_user`                    | Runtime application access   |
+| `{service}_provisioner` | `table_creator` + `app_user` | Dynamic table provisioning  |
+
+Passwords are supplied via env vars:
+
+```
+{SERVICE_UPPER}_MIGRATOR_PWD
+{SERVICE_UPPER}_APP_USER_PWD
+{SERVICE_UPPER}_PROVISIONER_PWD
+```
+
+Example for the `api_db`:
+
+```
+API_MIGRATOR_PWD=api_migrator_secret
+API_APP_USER_PWD=api_app_secret
+API_PROVISIONER_PWD=api_provisioner_secret
+```
+
+### Single-DB mode (backward compat)
+
+Omit `PG_MAE_DATABASES` and set `APP_DB_NAME` with the original single-role vars:
+
+```
+APP_DB_NAME=mae_test
+MIGRATOR_USER=db_migrator
+MIGRATOR_PWD=migrator_secret
+APP_USER=app
+APP_USER_PWD=secret
+TABLE_PROVISIONER_USER=table_provisioner
+TABLE_PROVISIONER_PWD=provisioner_secret
+```
+
+---
+
+## Connection Strings (local dev)
+
+Port is always **5432** (default Postgres).
+
+```
+# api service
+postgres://api_migrator:api_migrator_secret@localhost:5432/api_db
+postgres://api_app:api_app_secret@localhost:5432/api_db
+postgres://api_provisioner:api_provisioner_secret@localhost:5432/api_db
+
+# accounting service
+postgres://accounting_migrator:accounting_migrator_secret@localhost:5432/accounting_db
+postgres://accounting_app:accounting_app_secret@localhost:5432/accounting_db
+
+# widget service
+postgres://widget_migrator:widget_migrator_secret@localhost:5432/widget_db
+postgres://widget_app:widget_app_secret@localhost:5432/widget_db
+
+# queue service
+postgres://queue_migrator:queue_migrator_secret@localhost:5432/queue_db
+postgres://queue_app:queue_app_secret@localhost:5432/queue_db
+```
+
+---
+
+## Local Dev (Docker Compose)
+
+```bash
+docker compose up --build
+```
+
+This builds the image locally, initialises all 4 service databases, runs
+pgTAP tests, and keeps Postgres running.
+
+To rebuild on code changes:
+
+```bash
+docker compose watch
+```
+
+---
+
+## Running pgTAP Tests
+
+Tests are run automatically at startup in `APP_ENV=test`. To observe output:
+
+```bash
+# Show pgTAP output
+PG_TEST_LOG=1 docker compose up --build
+
+# Stream postgres logs too
+PG_LOG=1 docker compose up --build
+```
+
+To run the build-and-test cycle manually:
+
+```bash
+docker build -t pg-mae-schema-test . && docker run --rm pg-mae-schema-test 2>&1 | tail -30
+```
+
+---
+
+## Role Model (NOLOGIN roles, cluster-wide)
+
+| Role             | Purpose                                     |
+|------------------|---------------------------------------------|
+| `app_owner`      | Owns schemas + functions                    |
+| `app_migrator`   | Schema DDL (CREATE TABLE, indexes, etc.)    |
+| `table_creator`  | Dynamic table provisioning                  |
+| `app_user`       | Runtime DML (SELECT, INSERT, UPDATE, DELETE)|
+
+Per-service LOGIN roles inherit from these NOLOGIN roles. NOLOGIN roles are
+created by sqlx migrations (`migrations/000100_roles.sql`) and are shared
+cluster-wide across all databases on the instance.
+
+---
+
+## References
+
+- [pgTAP documentation](https://pgtap.org/documentation.html#has_column)
+- [pgpedia](https://pgpedia.info/search.html)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,26 @@
+# docker-compose.yml
+#
+# Local dev: runs postgres-mae with all 4 service databases initialized.
+#
+# Image: ghcr.io/mae-technologies/postgres-mae
+# Port:  5432 (default postgres port)
+#
+# Multi-DB mode is enabled by setting PG_MAE_DATABASES.
+# Each value is a database name; the service name is derived by stripping
+# a trailing _db suffix. Per-service login roles are created automatically:
+#   {service}_migrator  → inherits app_migrator + app_user
+#   {service}_app       → inherits app_user
+#   {service}_provisioner → inherits table_creator + app_user
+#
+# Connection strings (local dev):
+#   api:        postgres://api_migrator:api_migrator_secret@localhost:5432/api_db
+#   accounting: postgres://accounting_migrator:accounting_migrator_secret@localhost:5432/accounting_db
+#   widget:     postgres://widget_migrator:widget_migrator_secret@localhost:5432/widget_db
+#   queue:      postgres://queue_migrator:queue_migrator_secret@localhost:5432/queue_db
+
 services:
   postgres_mae:
-    image: postgres-mae:v18
+    image: ghcr.io/mae-technologies/postgres-mae:latest
     container_name: postgres-mae
     build: .
     develop:
@@ -12,37 +32,55 @@ services:
     volumes:
       - ./:/workspace
     environment:
-      # -----------------------------------------------------------------------------
-      # script config
-      # -----------------------------------------------------------------------------
-      APP_ENV: "test" # Only for pg_tests container; allowed: prod, dev, stage, test (case-insensitive)
-      DEBUG: "1" # Enable verbose logging in scripts
-      # PG_LOG: "1" # If set, stream postgres logs to stdout (pg_tests container only)
+      # -------------------------------------------------------------------------
+      # Script config
+      # -------------------------------------------------------------------------
+      APP_ENV: "test"
+      DEBUG: "1"
+      # PG_LOG: "1"
       # PG_TEST_LOG: "1"
 
-      # -----------------------------------------------------------------------------
+      # -------------------------------------------------------------------------
       # Database identity / networking
-      # -----------------------------------------------------------------------------
+      # -------------------------------------------------------------------------
       DB_HOST: "127.0.0.1"
-      DB_PORT: "2345" # FIXME: this is counterintuitive, the pg_db port should default to 5432
-      APP_DB_NAME: "mae_test"
+      DB_PORT: "5432"
 
-      # -----------------------------------------------------------------------------
+      # -------------------------------------------------------------------------
+      # Multi-DB mode: one DB per service
+      # -------------------------------------------------------------------------
+      PG_MAE_DATABASES: "api_db,accounting_db,widget_db,queue_db"
+
+      # -------------------------------------------------------------------------
       # Postgres bootstrap superuser
-      # -----------------------------------------------------------------------------
+      # -------------------------------------------------------------------------
       SUPERUSER: "postgres"
       SUPERUSER_PWD: "password"
 
-      # -----------------------------------------------------------------------------
-      # LOGIN roles
-      # -----------------------------------------------------------------------------
-      MIGRATOR_USER: "db_migrator"
-      MIGRATOR_PWD: "migrator_secret"
+      # -------------------------------------------------------------------------
+      # Per-service credentials
+      # Login roles created: {service}_migrator, {service}_app, {service}_provisioner
+      # -------------------------------------------------------------------------
 
-      APP_USER: "app"
-      APP_USER_PWD: "secret"
+      # api_db
+      API_MIGRATOR_PWD: "api_migrator_secret"
+      API_APP_USER_PWD: "api_app_secret"
+      API_PROVISIONER_PWD: "api_provisioner_secret"
 
-      TABLE_PROVISIONER_USER: "table_provisioner"
-      TABLE_PROVISIONER_PWD: "provisioner_secret"
+      # accounting_db
+      ACCOUNTING_MIGRATOR_PWD: "accounting_migrator_secret"
+      ACCOUNTING_APP_USER_PWD: "accounting_app_secret"
+      ACCOUNTING_PROVISIONER_PWD: "accounting_provisioner_secret"
+
+      # widget_db
+      WIDGET_MIGRATOR_PWD: "widget_migrator_secret"
+      WIDGET_APP_USER_PWD: "widget_app_secret"
+      WIDGET_PROVISIONER_PWD: "widget_provisioner_secret"
+
+      # queue_db
+      QUEUE_MIGRATOR_PWD: "queue_migrator_secret"
+      QUEUE_APP_USER_PWD: "queue_app_secret"
+      QUEUE_PROVISIONER_PWD: "queue_provisioner_secret"
+
     ports:
-      - "2345:2345"
+      - "5432:5432"

--- a/scripts/entry_point.sh
+++ b/scripts/entry_point.sh
@@ -4,54 +4,40 @@ set -euo pipefail
 stop_postgres_bounded() {
   set +e
   echo "Stopping postgres"
-
-  # Ask postgres to stop
   if [[ -n "${PGDATA:-}" && -d "${PGDATA}" ]]; then
     PGPASSWORD="${SUPERUSER_PWD}" pg_ctl -D "${PGDATA}" -m fast stop >/dev/null 2>&1 || true
   fi
-
   return 0
 }
 
 trap_run() {
   local code=$?
-  echo "critical failure (code=${code}), resetting database '${APP_DB_NAME}'..." >&2
-
+  echo "critical failure (code=${code}), resetting databases..." >&2
   set +e
 
-  # Provide app_db_name via --set and connect to a maintenance DB (postgres),
-  # because you can't drop the DB you're connected to.
-  PGPASSWORD="${SUPERUSER_PWD}" psql \
-    -h "${DB_HOST}" -p "${DB_PORT}" -U "${SUPERUSER}" \
-    -d postgres -v ON_ERROR_STOP=1 \
-    --set=app_db_name="${APP_DB_NAME}" --set=test_db_name="test" \
-    >/dev/null 2>&1 <<'SQL'
-REVOKE CONNECT ON DATABASE :"app_db_name" FROM PUBLIC;
-REVOKE CONNECT ON DATABASE :"test_db_name" FROM PUBLIC;
-REVOKE CONNECT ON DATABASE :"mae_db_name" FROM PUBLIC;
+  # Resolve database list for reset
+  if [[ -n "${PG_MAE_DATABASES:-}" ]]; then
+    IFS=',' read -ra _reset_dbs <<< "${PG_MAE_DATABASES}"
+  else
+    _reset_dbs=("${APP_DB_NAME:-postgres}")
+  fi
 
+  # Revoke connections and drop/recreate each database
+  for _raw_db in "${_reset_dbs[@]}"; do
+    _db="$(echo "${_raw_db}" | xargs)"
+    PGPASSWORD="${SUPERUSER_PWD}" psql \
+      -h "${DB_HOST}" -p "${DB_PORT}" -U "${SUPERUSER}" \
+      -d postgres -v ON_ERROR_STOP=1 \
+      --set=target_db="${_db}" \
+      >/dev/null 2>&1 <<'SQL'
+REVOKE CONNECT ON DATABASE :"target_db" FROM PUBLIC;
 SELECT pg_terminate_backend(pid)
 FROM pg_stat_activity
-WHERE datname = :'mae_db_name'
-  AND pid <> pg_backend_pid();
-
-SELECT pg_terminate_backend(pid)
-FROM pg_stat_activity
-WHERE datname = :'app_db_name'
-  AND pid <> pg_backend_pid();
-
-SELECT pg_terminate_backend(pid)
-FROM pg_stat_activity
-WHERE datname = :'test_db_name'
-  AND pid <> pg_backend_pid();
-
-DROP DATABASE IF EXISTS :"app_db_name" CASCADE;
-DROP DATABASE IF EXISTS :"test_db_name" CASCADE;
-DROP DATABASE IF EXISTS :"mae_db_name" CASCADE;
-CREATE DATABASE :"app_db_name";
-CREATE DATABASE :"test_db_name";
-CREATE DATABASE :"mae_db_name";
+WHERE datname = :'target_db' AND pid <> pg_backend_pid();
+DROP DATABASE IF EXISTS :"target_db";
+CREATE DATABASE :"target_db";
 SQL
+  done
 
   stop_postgres_bounded
 
@@ -59,25 +45,7 @@ SQL
   while true; do sleep 1; done
 }
 
-# ERR trap requires errtrace to propagate through functions/subshells.
 set -E
 trap trap_run ERR
 
 /workspace/scripts/run.sh
-
-# TODO: the reboot on testing is hacky -- it's a concern when going into bigger environments:
-# when we fail before testing, the current impl trys to actually close postgres entirely, making it flakey and unpredictable.
-# we'd be better off handling the different states of pg at the entrypoint, so we can handle it directly.
-# the migration logic is separated however, the 'run postgres' logic should be separate and protected pretty well
-# testing and teardown should be it's own script. teardown has to be pretty clean.
-# we can make a separate script for communicating with pg directly with the socket
-# the timing of the socket migrations were particular, these should sit in .sql files just like the others.
-# enviroment gathering and logging should be separated
-#
-# WARN: setting testing as the default env is dangerous, currently, if anybody was to start it with a volume attached would have their volumes wiped
-# we should migrate to a custom test flag for batch debugging and quick traveral.
-#
-# FUTURE: wire up logging, and a dashboard for this. but it would have to work for distributed systems.
-# FUTURE: distribution
-# FUTURE: direct vault connections
-# FUTURE: cryptographic storage

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -1,85 +1,46 @@
 #!/usr/bin/env bash
-# admin_migrations/sqlx_premigration_container.sh
+# run.sh
 #
-# Container entrypoint:
-# - starts postgres in THIS container
-# - loads /workspace/.env via ENV_PATH
-# - runs existing sqlx_premigration.sh with CONTAINER=-1
-# - suppresses postgres stdout unless error or PG_LOG is set
+# Container entrypoint (called by entry_point.sh):
+#  - starts postgres in this container
+#  - loads /workspace/.env via ENV_PATH
+#  - runs sqlx_premigration.sh (multi-DB aware)
+#  - runs pgTAP tests for every database and every principal
+#  - keeps postgres running in non-test mode
 
 set -euo pipefail
 
-# -----------------------------------------------------------------------------
-# Debug / TTY helpers (match premigration semantics)
-# -----------------------------------------------------------------------------
 is_debug() { [[ "${DEBUG:-}" == "1" ]]; }
 
-# -----------------------------------------------------------------------------
-# Logging helpers (emoji + two spaces, TTY-only)
-# -----------------------------------------------------------------------------
-c_reset="\033[0m"
-c_blue="\033[34m"
-c_green="\033[32m"
-c_yellow="\033[33m"
-c_red="\033[31m"
-
-log() {
-  echo -e "${c_blue}$*${c_reset}"
-}
-
-log_info() {
-  is_debug || return 0
-  echo -e "${c_blue}🔎${c_reset} $*"
-}
-
-log_ok() {
-  echo -e "${c_green}📟${c_reset} $*"
-}
-
-log_warn() {
-  echo -e "${c_yellow}😶${c_reset} $*"
-}
-
-log_err() {
-  echo -e "${c_red}🔥${c_reset} $*" >&2
-}
+c_reset="\033[0m"; c_blue="\033[34m"; c_green="\033[32m"; c_yellow="\033[33m"; c_red="\033[31m"
+log()      { echo -e "${c_blue}$*${c_reset}"; }
+log_info() { is_debug || return 0; echo -e "${c_blue}🔎${c_reset} $*"; }
+log_ok()   { echo -e "${c_green}📟${c_reset} $*"; }
+log_warn() { echo -e "${c_yellow}😶${c_reset} $*"; }
+log_err()  { echo -e "${c_red}🔥${c_reset} $*" >&2; }
 
 cd /workspace
 
 log_info "Container entrypoint starting"
 
-# -----------------------------------------------------------------------------
-# Load env with runtime overrides taking precedence (fallback to .env)
-#   - If a variable is already set in the environment, keep it.
-#   - Otherwise, populate it from the .env file.
-# -----------------------------------------------------------------------------
 export ENV_PATH="${ENV_PATH:-/workspace/.env}"
 if [[ ! -f "${ENV_PATH}" ]]; then
   log_err "ENV_PATH not found: ${ENV_PATH}"
   exit 1
 fi
 
-# Require variables (do NOT default)
 require_var() {
   local name="$1"
-  # ${!name+x} checks "is set", even if empty; then also reject empty explicitly
-  if [[ -z "${!name+x}" ]]; then
-    log_err "Required env var not set: ${name}"
-    exit 1
-  fi
-  if [[ -z "${!name}" ]]; then
-    log_err "Required env var is empty: ${name}"
+  if [[ -z "${!name+x}" || -z "${!name}" ]]; then
+    log_err "Required env var not set or empty: ${name}"
     exit 1
   fi
 }
 
-# Preserve runtime overrides for ALL vars in your .env (keep if already set)
 _preserve_var() {
   local name="$1"
   if [[ "${!name+x}" == "x" ]]; then
-    # Mark as preserved + store value (can be empty; still considered "set")
     eval "__preserve__${name}=1"
-    # printf %q to safely re-export later even with special chars
     eval "__value__${name}=$(printf '%q' "${!name}")"
   else
     eval "__preserve__${name}=0"
@@ -94,126 +55,74 @@ _restore_var() {
   fi
 }
 
-# List must match your .env variables (including optional/commented ones)
 _env_vars=(
   APP_ENV
-
-  DB_HOST
-  DB_PORT
-  APP_DB_NAME
-
-  SUPERUSER
-  SUPERUSER_PWD
-
-  MIGRATOR_USER
-  MIGRATOR_PWD
-
-  APP_USER
-  APP_USER_PWD
-
-  TABLE_PROVISIONER_USER
-  TABLE_PROVISIONER_PWD
-
+  DB_HOST DB_PORT APP_DB_NAME
+  SUPERUSER SUPERUSER_PWD
+  MIGRATOR_USER MIGRATOR_PWD
+  APP_USER APP_USER_PWD
+  TABLE_PROVISIONER_USER TABLE_PROVISIONER_PWD
+  PG_MAE_DATABASES
+  API_MIGRATOR_PWD API_APP_USER_PWD API_PROVISIONER_PWD
+  ACCOUNTING_MIGRATOR_PWD ACCOUNTING_APP_USER_PWD ACCOUNTING_PROVISIONER_PWD
+  WIDGET_MIGRATOR_PWD WIDGET_APP_USER_PWD WIDGET_PROVISIONER_PWD
+  QUEUE_MIGRATOR_PWD QUEUE_APP_USER_PWD QUEUE_PROVISIONER_PWD
 )
 
-for v in "${_env_vars[@]}"; do
-  _preserve_var "${v}"
-done
+for v in "${_env_vars[@]}"; do _preserve_var "${v}"; done
 
 log_info "Loading env from ${ENV_PATH}"
-set -a
-# shellcheck disable=SC1090
-source "${ENV_PATH}"
-set +a
+set -a; source "${ENV_PATH}"; set +a
 
-for v in "${_env_vars[@]}"; do
-  _restore_var "${v}"
-done
+for v in "${_env_vars[@]}"; do _restore_var "${v}"; done
 
-for v in "${_env_vars[@]}"; do
-  require_var "${v}"
-done
+for v in APP_ENV DB_HOST DB_PORT SUPERUSER SUPERUSER_PWD; do require_var "${v}"; done
 
 log_ok "Loaded env (runtime overrides preserved)"
 
-# -----------------------------------------------------------------------------
-# Require + validate APP_ENV (case-insensitive): test|dev|stage|prod
-# -----------------------------------------------------------------------------
-
 app_env_lc="$(printf '%s' "${APP_ENV}" | tr '[:upper:]' '[:lower:]')"
 case "${app_env_lc}" in
-test | dev | stage | prod) ;;
-*)
-  log_err "Invalid APP_ENV='${APP_ENV}' (allowed: test, dev, stage, prod)"
-  exit 1
-  ;;
+  test|dev|stage|prod) ;;
+  *) log_err "Invalid APP_ENV='${APP_ENV}'"; exit 1 ;;
 esac
-
 log_ok "Running in APP_ENV=${APP_ENV}"
 
-# -----------------------------------------------------------------------------
-# Mode flags
-# -----------------------------------------------------------------------------
 is_test_env=0
-if [[ "${app_env_lc}" == "test" ]]; then
-  is_test_env=1
-fi
+[[ "${app_env_lc}" == "test" ]] && is_test_env=1
 
-# Set to 1 when we decide the container should exit (test flow).
-# In non-test env, we aim to keep postgres running and never exit.
 should_exit=0
 
-# FIXME: I'm not a fan of exposting POSTGRES_USER and POSTGRES_PASSWORD -- if sqlx picks these up on a rouge script, it will blead into the public schema
-DATABASE_URL=postgres://${SUPERUSER}:${SUPERUSER_PWD}@${DB_HOST}:${DB_PORT}/${APP_DB_NAME}
 export POSTGRES_USER="${SUPERUSER}"
 export POSTGRES_PASSWORD="${SUPERUSER_PWD}"
-export DATABASE_URL
+export DATABASE_URL="postgres://${SUPERUSER}:${SUPERUSER_PWD}@${DB_HOST}:${DB_PORT}/${APP_DB_NAME:-postgres}"
 
-# Postgres logs:
-# - if PG_LOG is set: inherit stdout/stderr (verbose)
-# - else: redirect to a file; on failure, print tail for debugging
 pg_log_file="/tmp/postgres.log"
 
 log_info "Starting postgres on ${DB_HOST}:${DB_PORT} (APP_ENV=${APP_ENV})"
 
+# Port is always 5432 (default). DB_PORT kept for flexibility/override.
 if [[ "${app_env_lc}" != "test" ]]; then
-  # operational mode: show postgres logs on stdout/stderr
   docker-entrypoint.sh postgres -p "${DB_PORT}" -N 1000 &
 elif [[ -n "${PG_LOG:-}" ]]; then
   docker-entrypoint.sh postgres -p "${DB_PORT}" -N 1000 &
 else
   docker-entrypoint.sh postgres -p "${DB_PORT}" -N 1000 >"${pg_log_file}" 2>&1 &
 fi
-
 pg_pid="$!"
 
-# -----------------------------------------------------------------------------
-# Cleanup behavior:
-# - test: always stop postgres on exit (success or failure)
-# - non-test: keep postgres running; only stop it if the script is exiting due to failure
-# -----------------------------------------------------------------------------
 failed=0
 pg_started=1
 
 stop_postgres_bounded() {
   set +e
   log_info "Stopping postgres"
-
-  # Ask postgres to stop
   if [[ -n "${PGDATA:-}" && -d "${PGDATA}" ]]; then
     PGPASSWORD="${SUPERUSER_PWD}" pg_ctl -D "${PGDATA}" -m fast stop >/dev/null 2>&1 || true
   fi
-
-  # Bounded wait: avoid hanging forever if pg_pid isn't the server PID
   for _ in {1..20}; do
-    kill -0 "${pg_pid}" >/dev/null 2>&1 || {
-      log_ok "Postgres process exited"
-      return 0
-    }
+    kill -0 "${pg_pid}" >/dev/null 2>&1 || { log_ok "Postgres process exited"; return 0; }
     sleep 0.25
   done
-
-  # kill in 20 seconds, 0.25 * 20 = 200
   log_warn "Postgres PID still alive; sending SIGTERM"
   kill "${pg_pid}" >/dev/null 2>&1 || true
   return 0
@@ -221,44 +130,21 @@ stop_postgres_bounded() {
 
 cleanup() {
   set +e
-
-  # If postgres never started, nothing to do
-  if [[ -z "${pg_started:-}" || -z "${pg_pid:-}" ]]; then
-    return 0
-  fi
-
-  # TEST: always stop on exit
-  if [[ "${is_test_env}" == "1" ]]; then
-    log "Goodbye"
-    return 0
-  fi
-
-  # NON-TEST: operational mode
-  #
-  # cleanup() only runs when the script is exiting (SIGTERM/Ctrl-C) or postgres died.
-  # Distinguish:
-  #   - If postgres is still running: we are shutting down intentionally -> stop it.
-  #   - If postgres is not running: it already exited -> say goodbye (and rely on exit code).
+  if [[ -z "${pg_started:-}" || -z "${pg_pid:-}" ]]; then return 0; fi
+  if [[ "${is_test_env}" == "1" ]]; then log "Goodbye"; return 0; fi
   if [[ "${app_env_lc}" != "test" ]]; then
     if kill -0 "${pg_pid}" >/dev/null 2>&1; then
       log_warn "APP_ENV=${APP_ENV}; shutdown requested; stopping postgres"
       stop_postgres_bounded
-      log "Goodbye"
     else
-      # postgres already exited (crash or normal exit)
-      if [[ "${failed}" == "1" ]]; then
-        log_err "APP_ENV=${APP_ENV}; postgres already exited"
-      else
-        log_info "APP_ENV=${APP_ENV}; postgres already exited"
-      fi
-      log "Goodbye"
+      [[ "${failed}" == "1" ]] && log_err "APP_ENV=${APP_ENV}; postgres already exited"
     fi
+    log "Goodbye"
     return 0
   fi
 }
 trap cleanup EXIT
 
-# Wait readiness; on failure dump logs if suppressed
 deadline=$((SECONDS + 30))
 until pg_isready -h "${DB_HOST}" -p "${DB_PORT}" -U "${SUPERUSER}" >/dev/null 2>&1; do
   if ((SECONDS >= deadline)); then
@@ -268,20 +154,13 @@ until pg_isready -h "${DB_HOST}" -p "${DB_PORT}" -U "${SUPERUSER}" >/dev/null 2>
       tail -n 200 "${pg_log_file}" >&2 || true
       echo >&2 "-----------------------------"
     fi
-    failed=1
-    exit 1
+    failed=1; exit 1
   fi
   sleep 0.25
 done
 log_ok "Postgres is ready"
 
-# -----------------------------------------------------------------------------
-# Run premigration script (stdout/stderr passthrough)
-# -----------------------------------------------------------------------------
-
-# Run premigration script in local-postgres mode
-log_info "Running premigration script (local postgres mode)"
-
+log_info "Running premigration script"
 set +e
 /workspace/scripts/sqlx_premigration.sh
 rc=$?
@@ -289,91 +168,113 @@ set -e
 
 if [[ $rc -ne 0 ]]; then
   log_err "Premigration script failed (exit ${rc})"
-
-  # Only dump postgres logs when PG_LOG is not enabled
   if [[ -z "${PG_LOG:-}" && -f "${pg_log_file}" ]]; then
     echo >&2 "---- postgres.log (tail) ----"
     tail -n 200 "${pg_log_file}" >&2 || true
     echo >&2 "-----------------------------"
   fi
-  failed=1
-  exit $rc
+  failed=1; exit $rc
 fi
-
 log_ok "Premigration script finished"
 
-# TODO: move to it's own script
-# -----------------------------------------------------------------------------
-# pgTAP: run the suite as multiple principals (stop on first failure)
-# -----------------------------------------------------------------------------
-log_info "adding PGTap Extention..."
-PGPASSWORD="${SUPERUSER_PWD}" psql -h "${DB_HOST}" -p "${DB_PORT}" -U "${SUPERUSER}" \
-  -d "${APP_DB_NAME}" -v ON_ERROR_STOP=1 -q -c "
--- cannot drop the extension for public -> superuser requires it to run tests
-DROP EXTENSION IF EXISTS pgtap;
-CREATE EXTENSION IF NOT EXISTS pgtap WITH SCHEMA test;
-"
-log_ok "PGTap Extention added"
+# ─────────────────────────────────────────────────────────────────────────────
+# pgTAP: run for every database, every principal
+# ─────────────────────────────────────────────────────────────────────────────
+
+# Resolve database list (mirrors premigration logic)
+_multi_db_mode=0
+if [[ -n "${PG_MAE_DATABASES:-}" ]]; then
+  _multi_db_mode=1
+  IFS=',' read -ra _pgtap_databases <<< "${PG_MAE_DATABASES}"
+else
+  _pgtap_databases=("${APP_DB_NAME:-postgres}")
+fi
+
+get_service_var() {
+  local varname="${1}_${2}"
+  echo "${!varname:-}"
+}
 
 run_pgtap_as() {
-  local label="$1"
-  local user="$2"
-  local pwd="$3"
-  local dir="$4"
-
-  log_info "Running pgTAP as ${label} (${user})"
-
-  # Do NOT capture output in test mode; in non-test, optionally suppress unless PG_TEST_LOG=1
+  local label="$1" user="$2" pwd="$3" db="$4" dir="$5"
+  log_info "Running pgTAP as ${label} on ${db}"
+  local conn="postgres://${user}:${pwd}@${DB_HOST}:${DB_PORT}/${db}"
   if [[ "${PG_TEST_LOG:-}" == "1" ]]; then
-    pg_prove -v \
-      -d "postgres://${user}:${pwd}@${DB_HOST}:${DB_PORT}/${APP_DB_NAME}" \
-      --ext .sql \
-      $dir
+    pg_prove -v -d "${conn}" --ext .sql "${dir}"
   else
-    pg_prove -v \
-      -d "postgres://${user}:${pwd}@${DB_HOST}:${DB_PORT}/${APP_DB_NAME}" \
-      --ext .sql \
-      $dir >/dev/null
+    pg_prove -v -d "${conn}" --ext .sql "${dir}" >/dev/null
   fi
 }
 
 tests_failed=0
 tests_failed_rc=0
 tests_failed_role=""
+tests_failed_db=""
 
 set +e
 
-# Order matters: migrator often has the broadest runtime-ish permissions, app is tightest,
-# provisioner is capability-adjacent but inherits app_user DML in your model.
-for role_label in "SUPERUSER" "MIGRATOR_USER" "TABLE_PROVISIONER_USER" "APP_USER"; do
-  case "${role_label}" in
-  SUPERUSER)
-    run_pgtap_as "admin" "${SUPERUSER}" "${SUPERUSER_PWD}" "/workspace/tests"
-    rc=$?
-    ;;
-  MIGRATOR_USER)
-    run_pgtap_as "app_migrator" "${MIGRATOR_USER}" "${MIGRATOR_PWD}" "/workspace/tests/app_migrator_table_creator"
-    rc=$?
-    ;;
-  APP_USER)
-    run_pgtap_as "app_user" "${APP_USER}" "${APP_USER_PWD}" "/workspace/tests/app_user"
-    rc=$?
-    ;;
-  TABLE_PROVISIONER_USER)
-    run_pgtap_as "table_creator" "${TABLE_PROVISIONER_USER}" "${TABLE_PROVISIONER_PWD}" "/workspace/tests/app_migrator_table_creator"
-    rc=$?
-    ;;
-  *)
-    rc=1
-    ;;
-  esac
+for _raw_db in "${_pgtap_databases[@]}"; do
+  _db="$(echo "${_raw_db}" | xargs)"
+  _service="${_db%_db}"
+  _SERVICE="$(echo "${_service}" | tr '[:lower:]' '[:upper:]')"
 
-  if [[ $rc -ne 0 ]]; then
-    tests_failed=1
-    tests_failed_rc=$rc
-    tests_failed_role=$role_label
-    break
+  log_ok "── pgTAP: ${_db} ──"
+
+  # Add pgtap extension to this database
+  PGPASSWORD="${SUPERUSER_PWD}" psql \
+    -h "${DB_HOST}" -p "${DB_PORT}" -U "${SUPERUSER}" \
+    -d "${_db}" -v ON_ERROR_STOP=1 -q -c "
+DROP EXTENSION IF EXISTS pgtap;
+CREATE EXTENSION IF NOT EXISTS pgtap WITH SCHEMA test;
+"
+
+  # Resolve per-service credentials
+  if [[ "${_multi_db_mode}" == "1" ]]; then
+    _mig_user="${_service}_migrator"
+    _mig_pwd="$(get_service_var "${_SERVICE}" "MIGRATOR_PWD")"
+    _app_user="${_service}_app"
+    _app_pwd="$(get_service_var "${_SERVICE}" "APP_USER_PWD")"
+    _prov_user="${_service}_provisioner"
+    _prov_pwd="$(get_service_var "${_SERVICE}" "PROVISIONER_PWD")"
+  else
+    _mig_user="${MIGRATOR_USER:-db_migrator}"
+    _mig_pwd="${MIGRATOR_PWD:-}"
+    _app_user="${APP_USER:-app}"
+    _app_pwd="${APP_USER_PWD:-}"
+    _prov_user="${TABLE_PROVISIONER_USER:-table_provisioner}"
+    _prov_pwd="${TABLE_PROVISIONER_PWD:-}"
   fi
+
+  # Run tests as each principal (stop on first failure within DB)
+  for role_label in "SUPERUSER" "MIGRATOR" "TABLE_PROVISIONER" "APP_USER"; do
+    case "${role_label}" in
+      SUPERUSER)
+        run_pgtap_as "admin@${_db}" "${SUPERUSER}" "${SUPERUSER_PWD}" "${_db}" "/workspace/tests"
+        rc=$?
+        ;;
+      MIGRATOR)
+        run_pgtap_as "${_service}_migrator@${_db}" "${_mig_user}" "${_mig_pwd}" "${_db}" "/workspace/tests/app_migrator_table_creator"
+        rc=$?
+        ;;
+      TABLE_PROVISIONER)
+        run_pgtap_as "${_service}_provisioner@${_db}" "${_prov_user}" "${_prov_pwd}" "${_db}" "/workspace/tests/app_migrator_table_creator"
+        rc=$?
+        ;;
+      APP_USER)
+        run_pgtap_as "${_service}_app@${_db}" "${_app_user}" "${_app_pwd}" "${_db}" "/workspace/tests/app_user"
+        rc=$?
+        ;;
+      *) rc=1 ;;
+    esac
+
+    if [[ $rc -ne 0 ]]; then
+      tests_failed=1
+      tests_failed_rc=$rc
+      tests_failed_role="${role_label}"
+      tests_failed_db="${_db}"
+      break 2
+    fi
+  done
 done
 
 set -e
@@ -381,47 +282,34 @@ set -e
 if [[ "${tests_failed}" == "1" ]]; then
   log "___________________________"
   log ""
-  log_warn "PGTAP TESTS FAILED as ${tests_failed_role} (exit ${tests_failed_rc})"
+  log_warn "PGTAP TESTS FAILED as ${tests_failed_role} on ${tests_failed_db} (exit ${tests_failed_rc})"
   log ""
   log "___________________________"
 
-  # Dump postgres logs only if they were suppressed
   if [[ -z "${PG_LOG:-}" && -f "${pg_log_file}" && "${app_env_lc}" != "test" ]]; then
     echo >&2 "---- postgres.log (tail) ----"
     tail -n 200 "${pg_log_file}" >&2 || true
     echo >&2 "-----------------------------"
   fi
 
-  # Behavior:
-  # - test: keep postgres running for inspection and wait for reload
-  # - non-test: exit non-zero (cleanup decides whether to stop postgres)
   if [[ "${app_env_lc}" == "test" ]]; then
     log_warn "waiting for container reload..."
-    while true; do
-      sleep 1
-    done
+    while true; do sleep 1; done
   fi
 
-  failed=1
-  exit "${tests_failed_rc}"
+  failed=1; exit "${tests_failed_rc}"
 fi
 
 log "___________________________"
 log ""
-log_ok "pgTAP tests passed (all principals)"
+log_ok "pgTAP tests passed (all principals, all databases)"
 log "___________________________"
 
-#TODO: This should be at the bottom of the entrypoint script -> the final destination
-# -----------------------------------------------------------------------------
-# Final behavior:
-# - keep postgres running and stream logs
-# -----------------------------------------------------------------------------
 log_ok "APP_ENV=${APP_ENV}; postgres running (operational mode)"
 set +e
 wait "${pg_pid}"
 rc=$?
 set -e
-
 failed=1
 log_err "Postgres exited unexpectedly (exit ${rc})"
 exit "${rc}"

--- a/scripts/sqlx_premigration.sh
+++ b/scripts/sqlx_premigration.sh
@@ -1,107 +1,62 @@
 #!/usr/bin/bash
-# init_db.sh
+# sqlx_premigration.sh
 #
-# Starts local Postgres (Docker), creates LOGIN roles used by SQLx + the app,
-# runs migrations, and then grants membership to NOLOGIN roles.
+# Multi-database bootstrap for postgres-mae.
 #
-# Requirements implemented:
-#!/usr/bin/bash
-# init_db.sh
+# Supports two modes:
 #
-# Production/dev/CI bootstrap with a strict separation:
-#   - admin_migrations/: executed as SUPERUSER (high-trust). Contains 01-05 (roles/functions/lockdowns).
-#   - migrations/: executed as MIGRATOR_USER (low-trust). Contains normal app schema migrations.
+#   Single-DB (backward compat):
+#     Set APP_DB_NAME + MIGRATOR_USER/PWD + APP_USER/PWD + TABLE_PROVISIONER_USER/PWD
 #
-# Key security goals:
-#   - MIGRATOR_USER has minimal, typical production privileges
-#   - All role creation and sensitive privilege/ownership operations occur only under SUPERUSER
+#   Multi-DB (one DB per service):
+#     Set PG_MAE_DATABASES="api_db,accounting_db,widget_db,queue_db"
+#     Per-service creds are read from env vars:
+#       {SERVICE_UPPER}_MIGRATOR_PWD
+#       {SERVICE_UPPER}_APP_USER_PWD
+#       {SERVICE_UPPER}_PROVISIONER_PWD
+#     Where SERVICE is derived from the DB name by stripping a trailing _db suffix.
+#     e.g. api_db -> API, accounting_db -> ACCOUNTING
+#     Login role names: {service}_migrator, {service}_app, {service}_provisioner
 #
-# SQLx usage:
-#   - Admin migrations:
-#       sqlx migrate run --database-url <superuser-url> --source admin_migrations
-#   - App migrations:
-#       sqlx migrate run --database-url <migrator-url> --source migrations
-#
-# Output behavior:
-#   - Postgres (psql) output suppressed unless error
-#   - sqlx output NOT suppressed
-#   - Colored, emoji-prefixed stage logs (emoji + two spaces)
+# Security model:
+#   - NOLOGIN roles (app_user, app_migrator, table_creator, app_owner) are cluster-wide.
+#     Created by sqlx migrations (migrations/000100_roles.sql).
+#   - LOGIN roles are per-service and cluster-scoped.
+#   - Memberships are granted after migrations complete per-DB.
 
 set -eo pipefail
 
-is_debug() {
-  [[ "${DEBUG:-}" == "1" ]]
-}
+is_debug() { [[ "${DEBUG:-}" == "1" ]]; }
 
-# -----------------------------------------------------------------------------
-# Logging helpers (emoji + two spaces, TTY-only)
-# -----------------------------------------------------------------------------
-c_reset="\033[0m"
-c_blue="\033[34m"
-c_green="\033[32m"
-c_yellow="\033[33m"
-c_red="\033[31m"
+c_reset="\033[0m"; c_blue="\033[34m"; c_green="\033[32m"; c_yellow="\033[33m"; c_red="\033[31m"
+log_info() { is_debug || return 0; echo -e "${c_blue}🧩  $*${c_reset}"; }
+log_ok()   { echo -e "${c_green} $*${c_reset}"; }
+log_warn() { echo -e "${c_yellow}⚠️  $*${c_reset}"; }
+log_err()  { echo -e "${c_red}❌  $*${c_reset}" >&2; }
 
-log_info() {
-  is_debug || return 0
-  echo -e "${c_blue}🧩  $*${c_reset}"
-}
-
-log_ok() {
-  echo -e "${c_green} $*${c_reset}"
-}
-
-log_warn() {
-  echo -e "${c_yellow}⚠️  $*${c_reset}"
-}
-
-log_err() {
-  # stderr TTY check is more correct for errors
-  echo -e "${c_red}❌  $*${c_reset}" >&2
-}
-
-# -----------------------------------------------------------------------------
-# Tooling checks
-# -----------------------------------------------------------------------------
 if ! [ -x "$(command -v sqlx)" ]; then
   log_err "sqlx is not installed"
-  echo >&2 "Install:"
-  echo >&2 "  cargo install --version='~0.8' sqlx-cli --no-default-features --features rustls,postgres"
   exit 1
 fi
 
-# -----------------------------------------------------------------------------
-# Load env with runtime overrides taking precedence (fallback to .env)
-#   - If a variable is already set in the environment, keep it.
-#   - Otherwise, populate it from the .env file.
-# -----------------------------------------------------------------------------
 export ENV_PATH="${ENV_PATH:-.env}"
 if [[ ! -f "${ENV_PATH}" ]]; then
   log_err "ENV_PATH not found: ${ENV_PATH}"
   exit 1
 fi
 
-# Require variables (do NOT default)
 require_var() {
   local name="$1"
-  # ${!name+x} checks "is set", even if empty; then also reject empty explicitly
-  if [[ -z "${!name+x}" ]]; then
-    log_err "Required env var not set: ${name}"
-    exit 1
-  fi
-  if [[ -z "${!name}" ]]; then
-    log_err "Required env var is empty: ${name}"
+  if [[ -z "${!name+x}" || -z "${!name}" ]]; then
+    log_err "Required env var not set or empty: ${name}"
     exit 1
   fi
 }
 
-# Preserve runtime overrides for ALL vars in your .env (keep if already set)
 _preserve_var() {
   local name="$1"
   if [[ "${!name+x}" == "x" ]]; then
-    # Mark as preserved + store value (can be empty; still considered "set")
     eval "__preserve__${name}=1"
-    # printf %q to safely re-export later even with special chars
     eval "__value__${name}=$(printf '%q' "${!name}")"
   else
     eval "__preserve__${name}=0"
@@ -116,243 +71,202 @@ _restore_var() {
   fi
 }
 
-# List must match your .env variables (including optional/commented ones)
 _env_vars=(
-  DB_HOST
-  DB_PORT
-  APP_DB_NAME
-
-  SUPERUSER
-  SUPERUSER_PWD
-
-  MIGRATOR_USER
-  MIGRATOR_PWD
-
-  APP_USER
-  APP_USER_PWD
-
-  TABLE_PROVISIONER_USER
-  TABLE_PROVISIONER_PWD
-
-  SEARCH_PATH
+  DB_HOST DB_PORT APP_DB_NAME
+  SUPERUSER SUPERUSER_PWD
+  MIGRATOR_USER MIGRATOR_PWD
+  APP_USER APP_USER_PWD
+  TABLE_PROVISIONER_USER TABLE_PROVISIONER_PWD
+  SEARCH_PATH PG_MAE_DATABASES
+  API_MIGRATOR_PWD API_APP_USER_PWD API_PROVISIONER_PWD
+  ACCOUNTING_MIGRATOR_PWD ACCOUNTING_APP_USER_PWD ACCOUNTING_PROVISIONER_PWD
+  WIDGET_MIGRATOR_PWD WIDGET_APP_USER_PWD WIDGET_PROVISIONER_PWD
+  QUEUE_MIGRATOR_PWD QUEUE_APP_USER_PWD QUEUE_PROVISIONER_PWD
 )
 
-for v in "${_env_vars[@]}"; do
-  _preserve_var "${v}"
-done
+for v in "${_env_vars[@]}"; do _preserve_var "${v}"; done
 
 log_info "Loading env from ${ENV_PATH}"
-set -a
-# shellcheck disable=SC1090
-source "${ENV_PATH}"
-set +a
+set -a; source "${ENV_PATH}"; set +a
 
-for v in "${_env_vars[@]}"; do
-  _restore_var "${v}"
-done
+for v in "${_env_vars[@]}"; do _restore_var "${v}"; done
 
-for v in "${_env_vars[@]}"; do
-  require_var "${v}"
-done
+for v in DB_HOST DB_PORT SUPERUSER SUPERUSER_PWD SEARCH_PATH; do require_var "${v}"; done
 
 log_ok "Loaded env (runtime overrides preserved)"
 
-# -----------------------------------------------------------------------------
-# Quiet Postgres helpers (stdout suppressed; errors still shown)
-# -----------------------------------------------------------------------------
-psql_super_db() {
-  local db="$1"
-  local sql="$2"
+# Resolve database list
+_multi_db_mode=0
+if [[ -n "${PG_MAE_DATABASES:-}" ]]; then
+  _multi_db_mode=1
+  IFS=',' read -ra _databases <<< "${PG_MAE_DATABASES}"
+  log_ok "Multi-DB mode: ${PG_MAE_DATABASES}"
+else
+  require_var APP_DB_NAME
+  _databases=("${APP_DB_NAME}")
+  log_ok "Single-DB mode: ${APP_DB_NAME}"
+fi
 
-  PGPASSWORD="${SUPERUSER_PWD}" psql -h "${DB_HOST}" -p "${DB_PORT}" -U "${SUPERUSER}" \
+psql_super_db() {
+  local db="$1" sql="$2"
+  PGPASSWORD="${SUPERUSER_PWD}" psql \
+    -h "${DB_HOST}" -p "${DB_PORT}" -U "${SUPERUSER}" \
     -d "${db}" -v ON_ERROR_STOP=1 -q -c "${sql}" \
     1>/dev/null
-
 }
 
-# -----------------------------------------------------------------------------
-# 1) Ensure DB exists (as SUPERUSER)
-# -----------------------------------------------------------------------------
-log_info "Ensuring database exists via sqlx (superuser)"
-sqlx database create --database-url "${DATABASE_URL}"
+get_service_var() {
+  local varname="${1}_${2}"
+  echo "${!varname:-}"
+}
 
-log_ok "Database ensured"
+for _raw_db in "${_databases[@]}"; do
+  _db="$(echo "${_raw_db}" | xargs)"
+  _service="${_db%_db}"
+  _SERVICE="$(echo "${_service}" | tr '[:lower:]' '[:upper:]')"
 
-# Create mae schema for sqlx migrations
+  log_ok "── Setting up database: ${_db} (service: ${_service}) ──"
 
-psql_super_db "${APP_DB_NAME}" "
+  if [[ "${_multi_db_mode}" == "1" ]]; then
+    _mig_user="${_service}_migrator"
+    _mig_pwd="$(get_service_var "${_SERVICE}" "MIGRATOR_PWD")"
+    _app_user="${_service}_app"
+    _app_pwd="$(get_service_var "${_SERVICE}" "APP_USER_PWD")"
+    _prov_user="${_service}_provisioner"
+    _prov_pwd="$(get_service_var "${_SERVICE}" "PROVISIONER_PWD")"
 
+    [[ -z "${_mig_pwd}" ]]  && { log_err "Missing ${_SERVICE}_MIGRATOR_PWD for ${_db}";  exit 1; }
+    [[ -z "${_app_pwd}" ]]  && { log_err "Missing ${_SERVICE}_APP_USER_PWD for ${_db}";  exit 1; }
+    [[ -z "${_prov_pwd}" ]] && { log_err "Missing ${_SERVICE}_PROVISIONER_PWD for ${_db}"; exit 1; }
+  else
+    require_var MIGRATOR_USER; require_var MIGRATOR_PWD
+    require_var APP_USER; require_var APP_USER_PWD
+    require_var TABLE_PROVISIONER_USER; require_var TABLE_PROVISIONER_PWD
+    _mig_user="${MIGRATOR_USER}";          _mig_pwd="${MIGRATOR_PWD}"
+    _app_user="${APP_USER}";               _app_pwd="${APP_USER_PWD}"
+    _prov_user="${TABLE_PROVISIONER_USER}"; _prov_pwd="${TABLE_PROVISIONER_PWD}"
+  fi
+
+  _db_url="postgres://${SUPERUSER}:${SUPERUSER_PWD}@${DB_HOST}:${DB_PORT}/${_db}"
+
+  # 1) Create DB
+  log_info "Creating database ${_db}"
+  sqlx database create --database-url "${_db_url}"
+  log_ok "Database ${_db} created/exists"
+
+  # 2) Create schemas
+  psql_super_db "${_db}" "
 DO \$\$
 BEGIN
-    IF NOT EXISTS (
-        SELECT
-            1
-        FROM
-            pg_roles
-        WHERE
-            rolname = 'app_owner') THEN
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'app_owner') THEN
     CREATE ROLE app_owner NOLOGIN;
-END IF;
-    -- Create schema owned by app_owner
-    CREATE SCHEMA IF NOT EXISTS app AUTHORIZATION app_owner;
-    CREATE SCHEMA IF NOT EXISTS mae AUTHORIZATION app_owner;
-    CREATE SCHEMA IF NOT EXISTS test AUTHORIZATION app_owner;
+  END IF;
+  CREATE SCHEMA IF NOT EXISTS app  AUTHORIZATION app_owner;
+  CREATE SCHEMA IF NOT EXISTS mae  AUTHORIZATION app_owner;
+  CREATE SCHEMA IF NOT EXISTS test AUTHORIZATION app_owner;
 END
 \$\$;
-" >/dev/null 2>&1
+" 2>/dev/null
 
-# WARN: DROPPING SQLX for MAE. cannot drop any other migration tables as they're not ours! the public ones can be reapplied without error - and SHOULD be reapplied
-# Dropping sqlx table
-psql_super_db "${APP_DB_NAME}" "
-DROP TABLE IF EXISTS mae._sqlx_migrations;
-" >/dev/null 2>&1
+  # 3) Drop mae._sqlx_migrations to allow clean re-apply of mae-schema migrations
+  psql_super_db "${_db}" "DROP TABLE IF EXISTS mae._sqlx_migrations;" 2>/dev/null
 
-# -----------------------------------------------------------------------------
-# 2) Create LOGIN roles (as SUPERUSER) - these are actual DB users
-# -----------------------------------------------------------------------------
-log_info "Ensuring LOGIN roles exist (superuser)"
-psql_super_db "${APP_DB_NAME}" "
+  # 4) Create per-service LOGIN roles (cluster-level, idempotent)
+  log_info "Ensuring LOGIN roles for ${_service}"
+  psql_super_db "${_db}" "
 DO \$\$
 BEGIN
-  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = '${APP_USER}') THEN
-    CREATE ROLE ${APP_USER} LOGIN PASSWORD '${APP_USER_PWD}';
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = '${_mig_user}') THEN
+    CREATE ROLE ${_mig_user} LOGIN PASSWORD '${_mig_pwd}';
   END IF;
-
-  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = '${MIGRATOR_USER}') THEN
-    CREATE ROLE ${MIGRATOR_USER} LOGIN PASSWORD '${MIGRATOR_PWD}';
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = '${_app_user}') THEN
+    CREATE ROLE ${_app_user} LOGIN PASSWORD '${_app_pwd}';
   END IF;
-
-  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = '${TABLE_PROVISIONER_USER}') THEN
-    CREATE ROLE ${TABLE_PROVISIONER_USER} LOGIN PASSWORD '${TABLE_PROVISIONER_PWD}';
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = '${_prov_user}') THEN
+    CREATE ROLE ${_prov_user} LOGIN PASSWORD '${_prov_pwd}';
   END IF;
 END
 \$\$;
 "
-log_ok "LOGIN roles ensured"
+  log_ok "LOGIN roles ensured for ${_service}"
 
-# -----------------------------------------------------------------------------
-# 4) Run admin migrations as SUPERUSER against admin_migrations/
-# -----------------------------------------------------------------------------
-# This is where 01-05 live now (roles/functions/lockdowns).
-log_info "Running admin migrations"
-if [[ "${DEBUG:-}" == "1" ]]; then
-  sqlx migrate run --database-url "${DATABASE_URL}?options=-csearch_path%3Dmae"
-else
-  sqlx migrate run >/dev/null
-fi
-log_ok "Migrations applied"
+  # 5) Run sqlx migrations
+  log_info "Running migrations on ${_db}"
+  if [[ "${DEBUG:-}" == "1" ]]; then
+    sqlx migrate run --database-url "${_db_url}?options=-csearch_path%3Dmae"
+  else
+    sqlx migrate run --database-url "${_db_url}?options=-csearch_path%3Dmae" >/dev/null
+  fi
+  log_ok "Migrations applied to ${_db}"
 
-# -----------------------------------------------------------------------------
-# 5) Grant runtime memberships
-# -----------------------------------------------------------------------------
-# These roles are expected to be created by admin_migrations:
-#   - app_user
-#   - table_creator
-#   - migrator_user
-log_info "Granting role memberships"
+  # 6) Grant NOLOGIN memberships
+  log_info "Granting memberships for ${_service}"
 
-psql_super_db "${APP_DB_NAME}" "
+  # migrator -> app_migrator + app_user
+  psql_super_db "${_db}" "
 DO \$\$
 BEGIN
-  IF NOT EXISTS (
-    SELECT 1
-    FROM pg_auth_members m
-    JOIN pg_roles r_role   ON r_role.oid = m.roleid
-    JOIN pg_roles r_member ON r_member.oid = m.member
-    WHERE r_role.rolname = 'app_user'
-      AND r_member.rolname = '${APP_USER}'
-  ) THEN
-    EXECUTE format('GRANT %I TO %I', 'app_user', '${APP_USER}');
+  IF NOT EXISTS (SELECT 1 FROM pg_auth_members m
+    JOIN pg_roles rr ON rr.oid = m.roleid JOIN pg_roles rm ON rm.oid = m.member
+    WHERE rr.rolname = 'app_migrator' AND rm.rolname = '${_mig_user}') THEN
+    EXECUTE format('GRANT %I TO %I', 'app_migrator', '${_mig_user}');
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_auth_members m
+    JOIN pg_roles rr ON rr.oid = m.roleid JOIN pg_roles rm ON rm.oid = m.member
+    WHERE rr.rolname = 'app_user' AND rm.rolname = '${_mig_user}') THEN
+    EXECUTE format('GRANT %I TO %I', 'app_user', '${_mig_user}');
   END IF;
 END
 \$\$;
 "
 
-psql_super_db "${APP_DB_NAME}" "
+  # provisioner -> table_creator + app_user
+  psql_super_db "${_db}" "
 DO \$\$
 BEGIN
-  IF NOT EXISTS (
-    SELECT 1
-    FROM pg_auth_members m
-    JOIN pg_roles r_role   ON r_role.oid = m.roleid
-    JOIN pg_roles r_member ON r_member.oid = m.member
-    WHERE r_role.rolname = 'table_creator'
-      AND r_member.rolname = '${TABLE_PROVISIONER_USER}'
-  ) THEN
-    EXECUTE format('GRANT %I TO %I', 'table_creator', '${TABLE_PROVISIONER_USER}');
+  IF NOT EXISTS (SELECT 1 FROM pg_auth_members m
+    JOIN pg_roles rr ON rr.oid = m.roleid JOIN pg_roles rm ON rm.oid = m.member
+    WHERE rr.rolname = 'table_creator' AND rm.rolname = '${_prov_user}') THEN
+    EXECUTE format('GRANT %I TO %I', 'table_creator', '${_prov_user}');
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_auth_members m
+    JOIN pg_roles rr ON rr.oid = m.roleid JOIN pg_roles rm ON rm.oid = m.member
+    WHERE rr.rolname = 'app_user' AND rm.rolname = '${_prov_user}') THEN
+    EXECUTE format('GRANT %I TO %I', 'app_user', '${_prov_user}');
   END IF;
 END
 \$\$;
 "
 
-psql_super_db "${APP_DB_NAME}" "
+  # app login -> app_user
+  psql_super_db "${_db}" "
 DO \$\$
 BEGIN
-  IF NOT EXISTS (
-    SELECT 1
-    FROM pg_auth_members m
-    JOIN pg_roles r_role   ON r_role.oid = m.roleid
-    JOIN pg_roles r_member ON r_member.oid = m.member
-    WHERE r_role.rolname = 'app_migrator'
-      AND r_member.rolname = '${MIGRATOR_USER}'
-  ) THEN
-    EXECUTE format('GRANT %I TO %I', 'app_migrator', '${MIGRATOR_USER}');
+  IF NOT EXISTS (SELECT 1 FROM pg_auth_members m
+    JOIN pg_roles rr ON rr.oid = m.roleid JOIN pg_roles rm ON rm.oid = m.member
+    WHERE rr.rolname = 'app_user' AND rm.rolname = '${_app_user}') THEN
+    EXECUTE format('GRANT %I TO %I', 'app_user', '${_app_user}');
   END IF;
 END
 \$\$;
 "
 
-## Migrator inherits app_user privileges
-psql_super_db "${APP_DB_NAME}" "
-DO \$\$
-BEGIN
-  IF NOT EXISTS (
-    SELECT 1
-    FROM pg_auth_members m
-    JOIN pg_roles r_role   ON r_role.oid = m.roleid
-    JOIN pg_roles r_member ON r_member.oid = m.member
-    WHERE r_role.rolname = 'app_user'
-      AND r_member.rolname = '${MIGRATOR_USER}'
-  ) THEN
-    EXECUTE format('GRANT %I TO %I', 'app_user', '${MIGRATOR_USER}');
-  END IF;
-END
-\$\$;
+  log_ok "Memberships granted for ${_service}"
+
+  # 7) Set search_path per role
+  log_info "Setting search_path for ${_service} roles"
+  psql_super_db "${_db}" "
+ALTER ROLE ${_mig_user}  SET search_path = test, ${SEARCH_PATH}, mae;
+ALTER ROLE ${_prov_user} SET search_path = test, ${SEARCH_PATH};
+ALTER ROLE ${_app_user}  SET search_path = test, ${SEARCH_PATH};
 "
+  log_ok "search_path set for ${_service}"
+done
 
-## Table provisioner inherits app_user privileges
-psql_super_db "${APP_DB_NAME}" "
-DO \$\$
-BEGIN
-  IF NOT EXISTS (
-    SELECT 1
-    FROM pg_auth_members m
-    JOIN pg_roles r_role   ON r_role.oid = m.roleid
-    JOIN pg_roles r_member ON r_member.oid = m.member
-    WHERE r_role.rolname = 'app_user'
-      AND r_member.rolname = '${TABLE_PROVISIONER_USER}'
-  ) THEN
-    EXECUTE format('GRANT %I TO %I', 'app_user', '${TABLE_PROVISIONER_USER}');
-  END IF;
-END
-\$\$;
-"
-
-log_ok "Memberships granted"
-
-# -----------------------------------------------------------------------------
-# 6) Set scopes / search_path to roles
-# -----------------------------------------------------------------------------
-log_info "Setting search_path / scope to roles ${SEARCH_PATH}"
-psql_super_db "${APP_DB_NAME}" "
-  -- Set search_path
+# Set superuser search_path cluster-wide
+psql_super_db "${_databases[0]}" "
 ALTER ROLE ${SUPERUSER} SET search_path = test, ${SEARCH_PATH}, mae, public;
-  ALTER ROLE ${MIGRATOR_USER} SET search_path = test, ${SEARCH_PATH};
-  ALTER ROLE ${TABLE_PROVISIONER_USER} SET search_path = test, ${SEARCH_PATH};
-  ALTER ROLE ${APP_USER} SET search_path = test, ${SEARCH_PATH};
 "
-log_ok "Search_path's set"
 
-log_ok "Premigration Complete"
-
+log_ok "Premigration complete (${#_databases[@]} database(s))"
 exit 0


### PR DESCRIPTION
## Summary

Implements **issue #2** (one DB per service) and **issue #6** (CD manifest strategy decisions).

## What was done

### Issue #2 – One DB per service
- Refactored `scripts/sqlx_premigration.sh` to support `PG_MAE_DATABASES` env var
- For each DB in the list, the script: creates the database, creates schemas (app/mae/test), creates per-service LOGIN roles, runs sqlx migrations, grants NOLOGIN role memberships, sets search_paths
- Per-service login roles follow the pattern `{service}_migrator`, `{service}_app`, `{service}_provisioner`
- Passwords supplied via `{SERVICE_UPPER}_MIGRATOR_PWD`, `{SERVICE_UPPER}_APP_USER_PWD`, `{SERVICE_UPPER}_PROVISIONER_PWD`
- Backward compatible: when `PG_MAE_DATABASES` is not set, falls back to single-DB mode (existing `APP_DB_NAME` + credential vars)
- 4 databases configured: `api_db`, `accounting_db`, `widget_db`, `queue_db`

### Issue #6 – CD manifest strategy
- **Port**: changed from 2345 to 5432 (default Postgres; fixes counterintuitive non-standard port)  
- **Image registry**: `docker-compose.yml` references `ghcr.io/mae-technologies/postgres-mae:latest` (GHCR, not Docker Hub)
- **Bootstrap model**: postgres-mae runs as the postgres image; at startup runs pgTAP tests + admin migrations for every database
- **No init container**: bootstrap is self-contained — handled entirely by the entrypoint scripts
- **Multiple credential sets**: one set of login roles per service, scoped to that service's database

### pgTAP tests
- `scripts/run.sh` updated to run the full pgTAP test suite (all 4 principals) for every database
- All tests pass: 4 databases × 4 principals = 16 test runs ✅

## Verification

```
docker build -t pg-mae-schema-test .   ✅
docker run --rm pg-mae-schema-test     ✅ (pgTAP tests passed – all principals, all databases)
```

## Connection strings (local dev)

```
api:        postgres://api_migrator:api_migrator_secret@localhost:5432/api_db
accounting: postgres://accounting_migrator:accounting_migrator_secret@localhost:5432/accounting_db
widget:     postgres://widget_migrator:widget_migrator_secret@localhost:5432/widget_db
queue:      postgres://queue_migrator:queue_migrator_secret@localhost:5432/queue_db
```

Closes #2
Refs #6