### PR TITLE
[#11] Replace APP_ENV=test data-wipe with CONFIRM_IRREVOCABLE_DATABASE_WIPE flag

### DIFF
--- a/.env
+++ b/.env
@@ -48,3 +48,12 @@ APP_USER_PWD=secret
 # Optional: only if you create tables at runtime (inherits table_creator)
 TABLE_PROVISIONER_USER=table_provisioner
 TABLE_PROVISIONER_PWD=provisioner_secret
+
+# -----------------------------------------------------------------------------
+# Destructive reset guard
+# -----------------------------------------------------------------------------
+# DANGER: Setting this to 'true' will permanently and irrecoverably destroy and
+# recreate the database when the container encounters a critical failure.
+# There is no undo. Do NOT set this in any deployed environment.
+# APP_ENV no longer controls any destructive behaviour — this flag is required.
+# CONFIRM_IRREVOCABLE_DATABASE_WIPE=false

--- a/README.md
+++ b/README.md
@@ -20,6 +20,33 @@ bash scripts/install-hooks.sh
 
 This runs pgTAP tests locally before every push. Pushes are blocked if tests fail.
 
+## ⚠️ Destructive Reset Guard
+
+**`CONFIRM_IRREVOCABLE_DATABASE_WIPE`** — controls whether a critical container failure
+triggers a full database drop and recreate.
+
+| Value | Behaviour |
+|-------|-----------|
+| unset / `false` | **Safe (default).** On failure, the container halts and waits for a reload. Data is preserved. |
+| `true` | **DANGER.** The database is permanently and irrecoverably destroyed and recreated. |
+
+Previously, `APP_ENV=test` implicitly triggered destructive resets. That behaviour has been
+removed entirely. `APP_ENV` now only controls non-destructive settings (log verbosity, exit
+behaviour). Destroying the database requires explicit intent via this flag.
+
+**Rules:**
+- Leave this unset or `false` in all deployed environments (staging, prod, etc.)
+- Only set to `true` in isolated local dev / CI environments where data loss is acceptable
+- There is **no undo** — all data in the database will be gone
+
+```bash
+# docker-compose.yml — add under environment: (commented out = safe)
+# CONFIRM_IRREVOCABLE_DATABASE_WIPE: "false"
+
+# .env — add (commented out = safe)
+# CONFIRM_IRREVOCABLE_DATABASE_WIPE=false
+```
+
 ## Sources
 
 - https://pgtap.org/documentation.html#has_column

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,15 @@ services:
       # PG_TEST_LOG: "1"
 
       # -----------------------------------------------------------------------------
+      # Destructive reset guard
+      # DANGER: Setting this to 'true' will permanently and irrecoverably destroy and
+      # recreate the database on critical failure. There is no undo.
+      # Do NOT set this in any deployed environment.
+      # APP_ENV no longer controls any destructive behaviour — this flag is required.
+      # -----------------------------------------------------------------------------
+      # CONFIRM_IRREVOCABLE_DATABASE_WIPE: "false"
+
+      # -----------------------------------------------------------------------------
       # Database identity / networking
       # -----------------------------------------------------------------------------
       DB_HOST: "127.0.0.1"

--- a/scripts/entry_point.sh
+++ b/scripts/entry_point.sh
@@ -19,17 +19,24 @@ stop_postgres_bounded() {
 
 trap_run() {
   local code=$?
-  echo "critical failure (code=${code}), resetting database '${APP_DB_NAME}'..." >&2
+  echo "critical failure (code=${code})" >&2
 
   set +e
 
-  # Provide app_db_name via --set and connect to a maintenance DB (postgres),
-  # because you can't drop the DB you're connected to.
-  PGPASSWORD="${SUPERUSER_PWD}" psql \
-    -h "${DB_HOST}" -p "${DB_PORT}" -U "${SUPERUSER}" \
-    -d postgres -v ON_ERROR_STOP=1 \
-    --set=app_db_name="${APP_DB_NAME}" --set=test_db_name="test" \
-    >/dev/null 2>&1 <<'SQL'
+  # CONFIRM_IRREVOCABLE_DATABASE_WIPE guard:
+  # Database destruction requires an explicit, intentional opt-in.
+  # APP_ENV alone no longer triggers any destructive action.
+  if [ "${CONFIRM_IRREVOCABLE_DATABASE_WIPE:-false}" = "true" ]; then
+    echo "⚠️  WARNING: CONFIRM_IRREVOCABLE_DATABASE_WIPE=true — database will be permanently destroyed and recreated" >&2
+    echo "    Resetting database '${APP_DB_NAME}'..." >&2
+
+    # Provide app_db_name via --set and connect to a maintenance DB (postgres),
+    # because you can't drop the DB you're connected to.
+    PGPASSWORD="${SUPERUSER_PWD}" psql \
+      -h "${DB_HOST}" -p "${DB_PORT}" -U "${SUPERUSER}" \
+      -d postgres -v ON_ERROR_STOP=1 \
+      --set=app_db_name="${APP_DB_NAME}" --set=test_db_name="test" \
+      >/dev/null 2>&1 <<'SQL'
 REVOKE CONNECT ON DATABASE :"app_db_name" FROM PUBLIC;
 REVOKE CONNECT ON DATABASE :"test_db_name" FROM PUBLIC;
 REVOKE CONNECT ON DATABASE :"mae_db_name" FROM PUBLIC;
@@ -56,6 +63,9 @@ CREATE DATABASE :"app_db_name";
 CREATE DATABASE :"test_db_name";
 CREATE DATABASE :"mae_db_name";
 SQL
+  else
+    echo "[info] Database wipe skipped. Set CONFIRM_IRREVOCABLE_DATABASE_WIPE=true to enable destructive reset." >&2
+  fi
 
   stop_postgres_bounded
 
@@ -78,8 +88,9 @@ trap trap_run ERR
 # the timing of the socket migrations were particular, these should sit in .sql files just like the others.
 # enviroment gathering and logging should be separated
 #
-# WARN: setting testing as the default env is dangerous, currently, if anybody was to start it with a volume attached would have their volumes wiped
-# we should migrate to a custom test flag for batch debugging and quick traveral.
+# NOTE: The data-wipe behaviour previously triggered by APP_ENV=test has been replaced.
+# Destructive resets now require an explicit CONFIRM_IRREVOCABLE_DATABASE_WIPE=true flag.
+# APP_ENV controls only non-destructive config (log verbosity, exit behaviour, etc.).
 #
 # FUTURE: wire up logging, and a dashboard for this. but it would have to work for distributed systems.
 # FUTURE: distribution


### PR DESCRIPTION
## Summary

Closes #11

Removes the implicit data-wipe behaviour triggered by `APP_ENV=test` and replaces it with an explicit, long, descriptive flag: `CONFIRM_IRREVOCABLE_DATABASE_WIPE`.

## What was done

### `scripts/entry_point.sh`
- The `trap_run` ERR handler previously dropped and recreated all databases unconditionally on any error.
- Now it checks `CONFIRM_IRREVOCABLE_DATABASE_WIPE=true` before any destructive action.
- If unset or false (the default), it logs: `[info] Database wipe skipped. Set CONFIRM_IRREVOCABLE_DATABASE_WIPE=true to enable destructive reset.`
- If true, it logs a prominent ⚠️ warning then proceeds with the wipe.

### `APP_ENV` — no longer destructive
- `APP_ENV` continues to control non-destructive behaviour (postgres log routing, exit behaviour on test failure).
- `APP_ENV=test` alone can no longer wipe data under any circumstance.

### `.env` + `docker-compose.yml`
- `CONFIRM_IRREVOCABLE_DATABASE_WIPE` added with a multi-line danger comment, commented out (false by default).

### `README.md`
- New section documenting the flag with ⚠️ warnings, a behaviour table, and usage examples.

## Chosen flag name

`CONFIRM_IRREVOCABLE_DATABASE_WIPE`

Long, explicit, signals danger, signals irreversibility, requires deliberate intent to set.