### PR TITLE
chore: add podman for daemonless CI sidecar support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,17 @@ RUN set -eux; \
   rm -rf /var/lib/apt/lists/*
 
 # ----------------------------
+# Podman — daemonless container runtime for CI sidecars (e.g. neo4j).
+# Used by mae-integration-task to run neo4j:5 alongside postgres without DinD.
+# ----------------------------
+RUN set -eux; \
+  apt-get update; \
+  apt-get install -y --no-install-recommends \
+    podman \
+  ; \
+  rm -rf /var/lib/apt/lists/*
+
+# ----------------------------
 # Migration strategy: psql + ordered SQL files (no sqlx-cli)
 #
 # sqlx-cli has no prebuilt binaries and must be compiled from source via


### PR DESCRIPTION
## Summary
Add podman to the postgres-mae task image so Concourse integration tasks can run neo4j:5 as a daemonless sidecar alongside postgres. No Docker daemon (DinD) required — podman runs OCI images natively in privileged containers.

## Changes
- Dockerfile: add podman via apt-get

## Why
The mae-integration-task needs to start neo4j alongside postgres for widget-service integration tests. Podman is the clean solution: daemonless, fast up/down, no daemon footprint, works in privileged Concourse tasks.