### PR TITLE
feat: add Dockerfile.ci for postgres-mae:ci tag (podman for CI sidecars)

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,0 +1,11 @@
+# CI runner image — extends postgres-mae with podman for daemonless container sidecars.
+# This image is used by Concourse integration tasks; it is NOT the production postgres image.
+FROM ghcr.io/mae-technologies/postgres-mae:latest
+
+USER root
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      podman \
+      fuse-overlayfs \
+      uidmap \
+    && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Adds `Dockerfile.ci` that layers podman on top of `postgres-mae:latest`.

Built and pushed as `postgres-mae:ci` (stable) and `postgres-mae:main-<sha>-ci` (SHA-pinnable) by the Concourse pipeline (`build-ci` job in `postgres_mae.yml`).

Used by `mae-integration-task.yml` for neo4j podman sidecars in CI. Keeps `postgres-mae:latest` clean — no podman in the production postgres image.