### PR TITLE
fix: put SEARCH_PATH first in role search_path config — stop resolving to test schema by default

### DIFF
--- a/scripts/sqlx_premigration.sh
+++ b/scripts/sqlx_premigration.sh
@@ -343,10 +343,10 @@ log_ok "Memberships granted"
 # -----------------------------------------------------------------------------
 log_info "Setting search_path / scope to roles ${SEARCH_PATH}"
 psql_super_db "${APP_DB_NAME}" "
-ALTER ROLE ${SUPERUSER} SET search_path = test, ${SEARCH_PATH}, mae, public;
-ALTER ROLE ${MIGRATOR_USER} SET search_path = test, ${SEARCH_PATH};
-ALTER ROLE ${TABLE_PROVISIONER_USER} SET search_path = test, ${SEARCH_PATH};
-ALTER ROLE ${APP_USER} SET search_path = test, ${SEARCH_PATH};
+ALTER ROLE ${SUPERUSER} SET search_path = ${SEARCH_PATH}, mae, test, public;
+ALTER ROLE ${MIGRATOR_USER} SET search_path = ${SEARCH_PATH}, mae;
+ALTER ROLE ${TABLE_PROVISIONER_USER} SET search_path = ${SEARCH_PATH}, mae;
+ALTER ROLE ${APP_USER} SET search_path = ${SEARCH_PATH};
 "
 log_ok "Search_path's set"
 


### PR DESCRIPTION
## Summary

Fixes the root cause of `permission denied from schema test` during SQLx migrations in dev/prod environments.

## Root Cause

Step 6 of `scripts/sqlx_premigration.sh` was configuring all login roles with `test` schema first in their search_path:

```sql
-- Before (broken)
ALTER ROLE ${MIGRATOR_USER}         SET search_path = test, ${SEARCH_PATH};
ALTER ROLE ${TABLE_PROVISIONER_USER} SET search_path = test, ${SEARCH_PATH};
ALTER ROLE ${APP_USER}              SET search_path = test, ${SEARCH_PATH};
ALTER ROLE ${SUPERUSER}             SET search_path = test, ${SEARCH_PATH}, mae, public;
```

With `SEARCH_PATH=app` (dev/prod), roles connect with `search_path = test, app`. SQLx resolves `_sqlx_migrations` (and any unqualified table DDL) to the `test` schema first.

**Failure 1 — `app` user:** only has `USAGE` on `test` (no `CREATE`) → `permission denied from schema test` on first migration run.

**Failure 2 — `db_migrator` user:** has `CREATE` on `test`, so no permission error, but `_sqlx_migrations` and any unqualified DDL in service migration files land in `test` instead of `app`.

## Changes

`scripts/sqlx_premigration.sh` — flip search_path order to put `${SEARCH_PATH}` first:

```sql
-- After (fixed)
ALTER ROLE ${SUPERUSER}             SET search_path = ${SEARCH_PATH}, mae, test, public;
ALTER ROLE ${MIGRATOR_USER}         SET search_path = ${SEARCH_PATH}, mae;
ALTER ROLE ${TABLE_PROVISIONER_USER} SET search_path = ${SEARCH_PATH}, mae;
ALTER ROLE ${APP_USER}              SET search_path = ${SEARCH_PATH};
```

The `test` schema remains accessible to superuser for pgTAP tooling; it is no longer the default resolution target for production/dev roles.

Closes #53

## Test Results

No Rust code changed — this is a shell script fix. pgTAP tests do not assert search_path order. Existing tests should pass unchanged.