### PR TITLE
fix: allow unqualified _sqlx_migrations identity in block_disallowed_ddl

### DIFF
--- a/migrations/000700_block_disallowed_ddl.sql
+++ b/migrations/000700_block_disallowed_ddl.sql
@@ -29,7 +29,7 @@ BEGIN
             pg_event_trigger_ddl_commands () c
         WHERE
         -- SQLx bookkeeping table (schema-qualified or not depending on search_path)
-        c.object_identity LIKE 'test._sqlx_migrations%' OR c.object_identity LIKE 'app._sqlx_migrations%') THEN
+        c.object_identity LIKE 'test._sqlx_migrations%' OR c.object_identity LIKE 'app._sqlx_migrations%' OR c.object_identity LIKE '_sqlx_migrations%') THEN
         RETURN;
     END IF;
     -- Allow PGTap tests DDL for all role memberships (robust: uses object identity)


### PR DESCRIPTION
## Summary

Adds an unqualified fallback pattern to the `_sqlx_migrations` allowlist in the `trg_block_disallowed_ddl` event trigger.

## Changes

`migrations/000700_block_disallowed_ddl.sql`

Before:
```sql
c.object_identity LIKE 'test._sqlx_migrations%' OR c.object_identity LIKE 'app._sqlx_migrations%'
```

After:
```sql
c.object_identity LIKE 'test._sqlx_migrations%' OR c.object_identity LIKE 'app._sqlx_migrations%' OR c.object_identity LIKE '_sqlx_migrations%'
```

`pg_event_trigger_ddl_commands()` may return an unqualified `object_identity` (`_sqlx_migrations`) rather than a schema-qualified one. Without this fallback the allowlist misses and the trigger incorrectly blocks SQLx bookkeeping DDL even for valid `app_migrator` members.

Closes #55

## Test Results

SQL-only migration change (no Rust). No pre-push checks applicable.