### PR TITLE
Refactor DDL command handling in migration script

### DIFF
--- a/migrations/000700_block_disallowed_ddl.sql
+++ b/migrations/000700_block_disallowed_ddl.sql
@@ -41,7 +41,7 @@ BEGIN
               AND (cmd.schema_name IS NULL OR cmd.schema_name IN ('app', 'test', 'public'))
         )
     THEN
-        FOR c IN
+        FOR cmd IN
             SELECT
                 classid,
                 objid,

--- a/migrations/000700_block_disallowed_ddl.sql
+++ b/migrations/000700_block_disallowed_ddl.sql
@@ -40,13 +40,13 @@ BEGIN
         ) THEN
         RETURN;
     END IF;
-    FOR c IN SELECT * FROM pg_event_trigger_ddl_commands() LOOP
-        RAISE LOG 'tag=%, schema=%, identity=%, type=%',
-            c.command_tag,
-            c.schema_name,
-            c.object_identity,
-            c.object_type;
-    END LOOP;
+    DECLARE
+        c record;
+    BEGIN
+        FOR c IN SELECT * FROM pg_event_trigger_ddl_commands() LOOP
+            RAISE NOTICE '%', row_to_json(c);
+        END LOOP;
+    END;
     -- Allow PGTap tests DDL for all role memberships (robust: uses object identity)
     IF TG_TAG IN ('CREATE TABLE', 'ALTER TABLE', 'CREATE INDEX', 'CREATE TEMP TABLE', 'CREATE TEMP SEQUENCE', 'CREATE UNIQUE INDEX') AND EXISTS (
         SELECT

--- a/migrations/000700_block_disallowed_ddl.sql
+++ b/migrations/000700_block_disallowed_ddl.sql
@@ -36,9 +36,9 @@ BEGIN
        AND TG_TAG IN ('CREATE TABLE', 'ALTER TABLE', 'CREATE INDEX')
        AND EXISTS (
             SELECT 1
-            FROM pg_event_trigger_ddl_commands() c
-            WHERE c.object_identity ~ '(^|[.])_sqlx_migrations$'
-              AND (c.schema_name IS NULL OR c.schema_name IN ('app', 'test', 'public'))
+            FROM pg_event_trigger_ddl_commands() cmd
+            WHERE cmd.object_identity ~ '(^|[.])_sqlx_migrations$'
+              AND (cmd.schema_name IS NULL OR cmd.schema_name IN ('app', 'test', 'public'))
         )
     THEN
         FOR c IN

--- a/migrations/000700_block_disallowed_ddl.sql
+++ b/migrations/000700_block_disallowed_ddl.sql
@@ -30,7 +30,6 @@ BEGIN
     --               so it must be listed explicitly here.
     --
     -- Also allow when the effective_role itself is the migrator (compose restart cases).
-BEGIN
     IF (pg_has_role(invoker_role, 'app_migrator', 'member')
         OR pg_has_role(invoker_role, 'db_migrator', 'member')
         OR effective_role IN ('db_migrator', 'app_migrator'))

--- a/migrations/000700_block_disallowed_ddl.sql
+++ b/migrations/000700_block_disallowed_ddl.sql
@@ -30,34 +30,31 @@ BEGIN
             WHERE cmd.object_identity ~ '(^|[.])_sqlx_migrations$'
               AND (cmd.schema_name IS NULL OR cmd.schema_name IN ('app', 'test', 'public'))
         )
-    THEN
-        FOR cmd_rec IN
-            SELECT
-                classid,
-                objid,
-                objsubid,
-                command_tag,
-                object_type,
-                schema_name,
-                object_identity,
-                in_extension
-            FROM pg_event_trigger_ddl_commands()
-        LOOP
-            RAISE NOTICE
-                'classid=%, objid=%, objsubid=%, tag=%, type=%, schema=%, identity=%, in_extension=%',
-                cmd_rec.classid,
-                cmd_rec.objid,
-                cmd_rec.objsubid,
-                cmd_rec.command_tag,
-                cmd_rec.object_type,
-                cmd_rec.schema_name,
-                cmd_rec.object_identity,
-                cmd_rec.in_extension;
-        END LOOP;
-
-        RETURN;
+    THEN RETURN;
     END IF;
-
+    FOR cmd_rec IN
+        SELECT
+            classid,
+            objid,
+            objsubid,
+            command_tag,
+            object_type,
+            schema_name,
+            object_identity,
+            in_extension
+        FROM pg_event_trigger_ddl_commands()
+    LOOP
+        RAISE NOTICE
+            'classid=%, objid=%, objsubid=%, tag=%, type=%, schema=%, identity=%, in_extension=%',
+            cmd_rec.classid,
+            cmd_rec.objid,
+            cmd_rec.objsubid,
+            cmd_rec.command_tag,
+            cmd_rec.object_type,
+            cmd_rec.schema_name,
+            cmd_rec.object_identity,
+            cmd_rec.in_extension;
+    END LOOP;
     -- Allow PGTap tests DDL for all role memberships (robust: uses object identity)
     IF TG_TAG IN ('CREATE TABLE', 'ALTER TABLE', 'CREATE INDEX', 'CREATE TEMP TABLE', 'CREATE TEMP SEQUENCE', 'CREATE UNIQUE INDEX') AND EXISTS (
         SELECT

--- a/migrations/000700_block_disallowed_ddl.sql
+++ b/migrations/000700_block_disallowed_ddl.sql
@@ -43,8 +43,28 @@ BEGIN
     DECLARE
         c record;
     BEGIN
-        FOR c IN SELECT * FROM pg_event_trigger_ddl_commands() LOOP
-            RAISE NOTICE '%', row_to_json(c);
+        FOR c IN
+            SELECT
+                classid,
+                objid,
+                objsubid,
+                command_tag,
+                object_type,
+                schema_name,
+                object_identity,
+                in_extension
+            FROM pg_event_trigger_ddl_commands()
+        LOOP
+            RAISE NOTICE
+                'classid=%, objid=%, objsubid=%, tag=%, type=%, schema=%, identity=%, in_extension=%',
+                c.classid,
+                c.objid,
+                c.objsubid,
+                c.command_tag,
+                c.object_type,
+                c.schema_name,
+                c.object_identity,
+                c.in_extension;
         END LOOP;
     END;
     -- Allow PGTap tests DDL for all role memberships (robust: uses object identity)

--- a/migrations/000700_block_disallowed_ddl.sql
+++ b/migrations/000700_block_disallowed_ddl.sql
@@ -44,7 +44,7 @@ BEGIN
             in_extension
         FROM pg_event_trigger_ddl_commands()
     LOOP
-        RAISE NOTICE
+        RAISE WARNING
             'classid=%, objid=%, objsubid=%, tag=%, type=%, schema=%, identity=%, in_extension=%',
             cmd_rec.classid,
             cmd_rec.objid,

--- a/migrations/000700_block_disallowed_ddl.sql
+++ b/migrations/000700_block_disallowed_ddl.sql
@@ -10,38 +10,28 @@ CREATE FUNCTION mae._block_disallowed_ddl ()
     AS $$
 DECLARE
     effective_role text := CURRENT_USER;
-    -- definer/effective
     invoker_role text := SESSION_USER;
-    -- original login
     q text := current_query();
-    -- sql query
-    c record;
+    cmd_rec record;
     protected_cols text[] := ARRAY['id', 'sys_client', 'created_at', 'created_by', 'updated_at', 'updated_by', 'status', 'sys_detail', 'tags'];
     col text;
 BEGIN
-    -- Allow if the effective role is privileged (SECURITY DEFINER => app_owner)
     IF effective_role IN ('app_owner', 'postgres') THEN
         RETURN;
     END IF;
-    -- Allow SQLx bookkeeping DDL for any recognised migrator role (robust: uses object identity).
-    -- app_migrator: internal mae migrations.
-    -- db_migrator:  service-level role used by ru_api_service and similar consumers.
-    --               db_migrator is intentionally NOT a member of app_migrator (separate role hierarchy),
-    --               so it must be listed explicitly here.
-    --
-    -- Also allow when the effective_role itself is the migrator (compose restart cases).
+
     IF (pg_has_role(invoker_role, 'app_migrator', 'member')
         OR pg_has_role(invoker_role, 'db_migrator', 'member')
         OR effective_role IN ('db_migrator', 'app_migrator'))
        AND TG_TAG IN ('CREATE TABLE', 'ALTER TABLE', 'CREATE INDEX')
        AND EXISTS (
             SELECT 1
-            FROM pg_event_trigger_ddl_commands() cmd
+            FROM pg_event_trigger_ddl_commands() AS cmd
             WHERE cmd.object_identity ~ '(^|[.])_sqlx_migrations$'
               AND (cmd.schema_name IS NULL OR cmd.schema_name IN ('app', 'test', 'public'))
         )
     THEN
-        FOR cmd IN
+        FOR cmd_rec IN
             SELECT
                 classid,
                 objid,
@@ -55,14 +45,14 @@ BEGIN
         LOOP
             RAISE NOTICE
                 'classid=%, objid=%, objsubid=%, tag=%, type=%, schema=%, identity=%, in_extension=%',
-                c.classid,
-                c.objid,
-                c.objsubid,
-                c.command_tag,
-                c.object_type,
-                c.schema_name,
-                c.object_identity,
-                c.in_extension;
+                cmd_rec.classid,
+                cmd_rec.objid,
+                cmd_rec.objsubid,
+                cmd_rec.command_tag,
+                cmd_rec.object_type,
+                cmd_rec.schema_name,
+                cmd_rec.object_identity,
+                cmd_rec.in_extension;
         END LOOP;
 
         RETURN;

--- a/migrations/000700_block_disallowed_ddl.sql
+++ b/migrations/000700_block_disallowed_ddl.sql
@@ -33,15 +33,20 @@ BEGIN
         OR effective_role IN ('db_migrator', 'app_migrator'))
        AND TG_TAG IN ('CREATE TABLE', 'ALTER TABLE', 'CREATE INDEX')
        AND EXISTS (
-        SELECT
-            1
-        FROM
-            pg_event_trigger_ddl_commands () c
-        WHERE
-        -- SQLx bookkeeping table (schema-qualified or not depending on search_path)
-        c.object_identity LIKE 'test._sqlx_migrations%' OR c.object_identity LIKE 'app._sqlx_migrations%' OR c.object_identity LIKE '_sqlx_migrations') THEN
+            SELECT 1
+            FROM pg_event_trigger_ddl_commands() c
+            WHERE c.object_identity ~ '(^|[.])_sqlx_migrations$'
+              AND (c.schema_name IS NULL OR c.schema_name IN ('app', 'test', 'public'))
+        ) THEN
         RETURN;
     END IF;
+    FOR c IN SELECT * FROM pg_event_trigger_ddl_commands() LOOP
+        RAISE LOG 'tag=%, schema=%, identity=%, type=%',
+            c.command_tag,
+            c.schema_name,
+            c.object_identity,
+            c.object_type;
+    END LOOP;
     -- Allow PGTap tests DDL for all role memberships (robust: uses object identity)
     IF TG_TAG IN ('CREATE TABLE', 'ALTER TABLE', 'CREATE INDEX', 'CREATE TEMP TABLE', 'CREATE TEMP SEQUENCE', 'CREATE UNIQUE INDEX') AND EXISTS (
         SELECT

--- a/migrations/000700_block_disallowed_ddl.sql
+++ b/migrations/000700_block_disallowed_ddl.sql
@@ -14,6 +14,8 @@ DECLARE
     invoker_role text := SESSION_USER;
     -- original login
     q text := current_query();
+    -- sql query
+    c record;
     protected_cols text[] := ARRAY['id', 'sys_client', 'created_at', 'created_by', 'updated_at', 'updated_by', 'status', 'sys_detail', 'tags'];
     col text;
 BEGIN
@@ -28,6 +30,7 @@ BEGIN
     --               so it must be listed explicitly here.
     --
     -- Also allow when the effective_role itself is the migrator (compose restart cases).
+BEGIN
     IF (pg_has_role(invoker_role, 'app_migrator', 'member')
         OR pg_has_role(invoker_role, 'db_migrator', 'member')
         OR effective_role IN ('db_migrator', 'app_migrator'))
@@ -37,12 +40,8 @@ BEGIN
             FROM pg_event_trigger_ddl_commands() c
             WHERE c.object_identity ~ '(^|[.])_sqlx_migrations$'
               AND (c.schema_name IS NULL OR c.schema_name IN ('app', 'test', 'public'))
-        ) THEN
-        RETURN;
-    END IF;
-    DECLARE
-        c record;
-    BEGIN
+        )
+    THEN
         FOR c IN
             SELECT
                 classid,
@@ -66,7 +65,10 @@ BEGIN
                 c.object_identity,
                 c.in_extension;
         END LOOP;
-    END;
+
+        RETURN;
+    END IF;
+
     -- Allow PGTap tests DDL for all role memberships (robust: uses object identity)
     IF TG_TAG IN ('CREATE TABLE', 'ALTER TABLE', 'CREATE INDEX', 'CREATE TEMP TABLE', 'CREATE TEMP SEQUENCE', 'CREATE UNIQUE INDEX') AND EXISTS (
         SELECT


### PR DESCRIPTION
Simplified the conditional block by removing the loop for raising notices.